### PR TITLE
Adding known issue for 15.6 publish

### DIFF
--- a/VS-AzureTools-ReleaseNotes.md
+++ b/VS-AzureTools-ReleaseNotes.md
@@ -3,6 +3,13 @@
 These are the changes to each version that has been released
 on the official Visual Studio extension Marketplace.
 
+# Known Issues
+## Visual Studio 15.6
+   * ### Issue:
+   Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
+   * ### Workaround
+   This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
+
 # 15.0.40405.0
 Minimum required Visual Studio version: VS2017 15.6
 

--- a/VS-AzureTools-ReleaseNotes.md
+++ b/VS-AzureTools-ReleaseNotes.md
@@ -6,9 +6,9 @@ on the official Visual Studio extension Marketplace.
 # Known Issues
 ## Visual Studio 15.6
    * ### Issue:
-    Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
+     Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
    * ### Workaround
-    This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
+     This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
 
 # Release Notes
 ## 15.0.40405.0

--- a/VS-AzureTools-ReleaseNotes.md
+++ b/VS-AzureTools-ReleaseNotes.md
@@ -6,9 +6,9 @@ on the official Visual Studio extension Marketplace.
 # Known Issues
 ## Visual Studio 15.6
    * ### Issue:
-   Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
+    Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
    * ### Workaround
-   This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
+    This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
 
 # Release Notes
 ## 15.0.40405.0

--- a/VS-AzureTools-ReleaseNotes.md
+++ b/VS-AzureTools-ReleaseNotes.md
@@ -10,14 +10,15 @@ on the official Visual Studio extension Marketplace.
    * ### Workaround
    This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
 
-# 15.0.40405.0
+# Release Notes
+## 15.0.40405.0
 Minimum required Visual Studio version: VS2017 15.6
 
 - Updates Azure Functions V1 templates to 1.0.3.10178
 - Updates Azure Functions V2 templates to 2.0.0-beta-10177
 - Updates Azure Functions Core Tools to  2.0.1-beta.25
 
-# 15.0.40322.0
+## 15.0.40322.0
 Minimum required Visual Studio version: VS2017 15.6
 
 - Fix a bug where running and publishing a v2 Functions app with the latest runtime failed

--- a/VS-AzureTools-ReleaseNotes.md
+++ b/VS-AzureTools-ReleaseNotes.md
@@ -6,7 +6,7 @@ on the official Visual Studio extension Marketplace.
 # Known Issues
 ## Visual Studio 15.6
    * ### Issue:
-     Create a new App Service Plan during publish from Visual Studio fails with a message like "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
+     Creating a new App Service Plan from Visual Studio fails with a message similar to "The resource '<storage_account>' under resource group '<your_resource_group>' was not found.
    * ### Workaround
      This error occurs when you select a Storage Account that is in a different resource group than the Resource Group selection in the dialog.  Either choose the same resource group in the dialog, or create a new storage account.  
 


### PR DESCRIPTION
15.6 introduced the ability to choose an existing storage account, but this fails if the storage account is in a different resource group than the app service plan (fixed in 15.7)