### PR TITLE
adding combined host.json schema

### DIFF
--- a/schemas/host.json
+++ b/schemas/host.json
@@ -1,0 +1,493 @@
+﻿{
+  "title": "JSON schema for Azure Functions host.json files",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+
+  "definitions": {
+
+    "aggregator": {
+      "description": "Configuration settings for the function result aggregator.",
+      "type": "object",
+      "properties": {
+        "batchSize": {
+          "description": "The maximum batch size for aggregations. If this value is reached before the 'flushTimeout', all values will be flushed.",
+          "type": "integer",
+          "default": 1000
+        },
+        "flushTimeout": {
+          "description": "The aggregation duration. The aggregator will flush periodically based on this value.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:00:30"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "functions": {
+      "description": "The list of functions the host should load.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "uniqueItems": true
+      }
+    },
+
+    "functionTimeout": {
+      "description": "Value indicating the timeout duration for all functions.",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$"
+        },
+        { "enum": [ null ] }
+      ]
+    },
+
+    "watchDirectories": {
+      "description": "Set of shared code directories that should be monitored for changes to ensure that when code in these directories is changed, it is picked up by your functions",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "uniqueItems": true
+      }
+    },
+
+    "singleton": {
+      "description": "Configuration settings for Singleton lock behavior.",
+      "type": "object",
+      "properties": {
+        "lockPeriod": {
+          "description": "The period that function level locks are taken for (they will auto renew).",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:00:15"
+        },
+        "listenerLockPeriod": {
+          "description": "The period that listener locks are taken for.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:01:00"
+        },
+        "listenerLockRecoveryPollingInterval": {
+          "description": "The time interval used for listener lock recovery if a listener lock couldn't be acquired on startup.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:01:00"
+        },
+        "lockAcquisitionTimeout": {
+          "description": "The maximum amount of time the runtime will try to acquire a lock.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:01:00"
+        },
+        "lockAcquisitionPollingInterval": {
+          "description": "The interval between lock acquisition attempts.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "healthMonitor": {
+      "description": "Configuration settings for the Functions host health monitor",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Specifies whether the feature is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "healthCheckInterval": {
+          "description": "The time interval between the periodic background health checks",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:00:10"
+        },
+        "healthCheckWindow": {
+          "description": "A sliding time window used in conjunction with the healthCheckThreshold setting.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:02:00"
+        },
+        "healthCheckThreshold": {
+          "description": "Maximum number of times the health check can fail before a host recycle is initiated.",
+          "type": "integer",
+          "default": 6
+        },
+        "counterThreshold": {
+          "description": "The threshold at which a performance counter will be considered unhealthy.",
+          "type": "number",
+          "default": 0.80
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "http-extension": {
+      "type": "object",
+      "description": "Configuration settings for 'http' triggers.",
+      "required": [ "routePrefix" ],
+      "properties": {
+        "routePrefix": {
+          "description": "Defines the default route prefix that applies to all routes. Use an empty string to remove the prefix.",
+          "type": "string",
+          "default": "api"
+        },
+        "maxConcurrentRequests": {
+          "description": "Defines the the maximum number of http functions that will execute in parallel.",
+          "type": "integer",
+          "default": -1
+        },
+        "maxOutstandingRequests": {
+          "description": "Defines the maximum number of oustanding requests that will be held at any given time.",
+          "type": "integer",
+          "default": -1
+        },
+        "dynamicThrottlesEnabled": {
+          "description": "Indicates whether dynamic host counter checks should be enabled.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "queues-extension": {
+      "description": "Configuration settings for 'queue' triggers.",
+      "type": "object",
+      "properties": {
+        "maxPollingInterval": {
+          "description": "The maximum interval in milliseconds between queue polls.",
+          "type": "integer",
+          "default": 1000
+        },
+        "batchSize": {
+          "description": "The number of queue messages to retrieve and process in parallel (per job function).",
+          "type": "integer",
+          "maximum": 32,
+          "minimum": 1,
+          "default": 16
+        },
+        "maxDequeueCount": {
+          "description": "The number of times to try processing a message before moving it to the poison queue",
+          "type": "integer",
+          "default": 5
+        },
+        "newBatchThreshold": {
+          "description": "The threshold at which a new batch of messages will be fetched. The default is batchSize/2.",
+          "type": "integer"
+        },
+        "visibilityTimeout": {
+          "description": "The visibility timeout that will be applied to messages that fail processing.",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:00:00"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "eventHubs-extension": {
+      "description": "Configuration settings for 'eventHub' triggers.",
+      "type": "object",
+      "properties": {
+        "maxBatchSize": {
+          "description": "The maximum event count received per receive loop.",
+          "type": "integer"
+        },
+        "receiveTimeout": {
+          "description": "the timespan in which the user is willing to wait when the event processor is performing a receive operation.",
+          "type": "string",
+          "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+          "default": "00:01:00"
+        },
+        "enableReceiverRuntimeMetric": {
+          "description": "Value indicating whether the runtime metric of a receiver is enabled.",
+          "type": "boolean"
+        },
+        "prefetchCount": {
+          "description": "The default PrefetchCount that will be used by the underlying EventProcessorHost.",
+          "type": "integer"
+        },
+        "invokeProcessorAfterReceiveTimeout": {
+          "description": "Value indicating whether the processor should be invoked after every ReceiveTimeout when there are no more messages in the stream for a partition.",
+          "type": "boolean"
+        },
+        "batchCheckpointFrequency": {
+          "description": "The number of batches to process before creating an EventHub cursor checkpoint",
+          "type": "integer",
+          "default": 1
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "durableTask-extension": {
+      "description": "Configuration settings for 'orchestration'/'activity' triggers.",
+      "type": "object",
+      "properties": {
+        "hubName": {
+          "description": "The logical container for Azure Storage resources that are used for orchestrations.",
+          "type": "string",
+          "default": "DurableFunctionsHub"
+        },
+        "azureStorageConnectionStringName": {
+          "description": "An app setting (or environment variable) with the storage connection string to be used by the orchestration/activity trigger.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "cosmosDB-extension": {
+      "description": "Configuration settings for Azure Cosmos DB bindings and triggers.",
+      "type": "object",
+      "properties": {
+        "connectionMode": {
+          "description": "ConnectionMode to be used on the DocumentClients.",
+          "enum": [ "Gateway", "Direct" ],
+          "default": "Gateway"
+        },
+        "protocol": {
+          "description": "Protocol to be used on the DocumentClients.",
+          "enum": [ "Https", "Tcp" ],
+          "default": "Https"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "version-1": {
+      "type": "object",
+      "properties": {
+        "aggregator": { "$ref": "#/definitions/aggregator" },
+        "applicationInsights": {
+          "description": "Configuration settings for Application Insights logging.",
+          "type": "object",
+          "properties": {
+            "sampling": {
+              "description": "Configuration settings for Application Insights client-side adaptive sampling.",
+              "type": "object",
+              "properties": {
+                "isEnabled": {
+                  "description": "If true, client-side adaptive sampling is enabled.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "maxTelemetryItemsPerSecond": {
+                  "description": "The target rate that the adaptive algorithm aims for on each instance",
+                  "type": "integer",
+                  "default": 5
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "functions": { "$ref": "#/definitions/functions" },
+        "functionTimeout": { "$ref": "#/definitions/functionTimeout" },
+        "healthMonitor": { "$ref": "#/definitions/healthMonitor" },
+        "id": {
+          "description": "The unique ID for this job host. Can be a lower case GUID with dashes removed",
+          "type": "string",
+          "minLength": 1
+        },
+        "logger": {
+          "description": "Configuration settings for logging.",
+          "type": "object",
+          "properties": {
+            "defaultLevel": {
+              "description": "The default level for logging. If a category level is not specified, this value is used.",
+              "enum": [ "Critical", "Debug", "Error", "Information", "None", "Trace", "Warning" ],
+              "default": "Information"
+            },
+            "categoryLevels": {
+              "description": "Log levels for specific categories.",
+              "type": "object",
+              "additionalProperties": {
+                "enum": [ "Critical", "Debug", "Error", "Information", "None", "Trace", "Warning" ]
+              }
+            }
+          }
+        },
+        "singleton": { "$ref": "#/definitions/singleton" },
+        "watchDirectories": { "$ref": "#/definitions/watchDirectories" },
+        "tracing": {
+          "description": "Configuration settings for logging/tracing behavior.",
+          "type": "object",
+          "properties": {
+            "consoleLevel": {
+              "description": "The tracing level used for console logging.",
+              "enum": [ "off", "error", "warning", "info", "verbose" ],
+              "default": "verbose"
+            },
+            "fileLoggingMode": {
+              "description": "Value determining what level of file logging is enabled.",
+              "enum": [ "never", "always", "debugOnly" ],
+              "default": "debugOnly"
+            }
+          },
+          "additionalProperties": false
+        },
+        "http": { "$ref": "#/definitions/http-extension" },
+        "queues": { "$ref": "#/definitions/queues-extension" },
+        "serviceBus": {
+          "description": "Configuration settings for 'serviceBus' triggers.",
+          "type": "object",
+          "properties": {
+            "maxConcurrentCalls": {
+              "description": "The maximum number of concurrent calls to the callback the message pump should initiate.",
+              "type": "integer",
+              "default": 16
+            },
+            "prefetchCount": {
+              "description": "The default PrefetchCount that will be used by the underlying MessageReceiver.",
+              "type": "integer"
+            },
+            "autoRenewTimeout": {
+              "description": "The maximum duration within which the Service Bus message lock will be renewed automatically.",
+              "type": "string",
+              "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+              "default": "00:05:00"
+            },
+            "autoComplete": {
+              "description": "Specifies whether messages should be automatically completed after successful processing.",
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "eventHub": { "$ref": "#/definitions/eventHubs-extension" },
+        "durableTask": { "$ref": "#/definitions/durableTask-extension" },
+        "documentDB": { "$ref": "#/definitions/cosmosDB-extension" }
+      },
+      "additionalProperties": false
+    },
+
+    "version-2": {
+      "type": "object",
+      "properties": {
+        "aggregator": { "$ref": "#/definitions/aggregator" },
+        "functions": { "$ref": "#/definitions/functions" },
+        "functionTimeout": { "$ref": "#/definitions/functionTimeout" },
+        "healthMonitor": { "$ref": "#/definitions/healthMonitor" },
+        "languageWorker": {
+          "description": "Configuration settings for Language Workers.",
+          "type": "object",
+          "properties": {
+            "maxMessageLength": {
+              "description": "Defines maximum message size in MegaBytes (MB) for the streaming messages between the functions host and a language worker",
+              "type": "integer",
+              "minimum": 4,
+              "default": 32
+            },
+            "workersDirectory": {
+              "description": "Specifies full path of the directory for language workers",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "logging": {
+          "description": "Configuration settings for logging.",
+          "type": "object",
+          "properties": {
+            "logLevel": {
+              "description": "Log levels for specific categories.",
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "The default level for logging. If a category level is not specified, this value is used.",
+                  "enum": [ "Critical", "Debug", "Error", "Information", "None", "Trace", "Warning" ],
+                  "default": "Information"
+                }
+              },
+              "additionalProperties": {
+                "enum": [ "Critical", "Debug", "Error", "Information", "None", "Trace", "Warning" ]
+              }
+            },
+            "applicationInsights": {
+              "description": "Configuration settings for Application Insights logging.",
+              "type": "object",
+              "properties": {
+                "samplingSettings": {
+                  "description": "Configuration settings for Application Insights client-side adaptive sampling.",
+                  "type": "object",
+                  "properties": {
+                    "isEnabled": {
+                      "description": "If true, client-side adaptive sampling is enabled.",
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "maxTelemetryItemsPerSecond": {
+                      "description": "The target rate that the adaptive algorithm aims for on each instance",
+                      "type": "integer",
+                      "default": 5
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "fileLoggingMode": {
+              "description": "Value determining what level of file logging is enabled.",
+              "enum": [ "never", "always", "debugOnly" ],
+              "default": "debugOnly"
+            }
+          }
+        },
+        "singleton": { "$ref": "#/definitions/singleton" },
+        "watchDirectories": { "$ref": "#/definitions/watchDirectories" },
+        "version": {
+          "description": "The version of the function application.",
+          "enum": [ "2.0" ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "http": { "$ref": "#/definitions/http-extension" },
+            "queues": { "$ref": "#/definitions/queues-extension" },
+            "serviceBus": {
+              "description": "Configuration settings for 'serviceBus' triggers.",
+              "type": "object",
+              "properties": {
+                "prefetchCount": {
+                  "description": "The default PrefetchCount that will be used by the underlying MessageReceiver.",
+                  "type": "integer"
+                },
+                "messageHandlerOptions": {
+                  "description": "The options that will be used for the message handler registered with the MessageReceiver.",
+                  "type": "object",
+                  "properties": {
+                    "maxConcurrentCalls": {
+                      "description": "The maximum number of concurrent calls to the callback the message pump should initiate.",
+                      "type": "integer",
+                      "default": 16
+                    },
+                    "maxAutoRenewTimeout": {
+                      "description": "The maximum duration within which the Service Bus message lock will be renewed automatically.",
+                      "type": "string",
+                      "pattern": "^\\d\\d:\\d\\d:\\d\\d$",
+                      "default": "00:05:00"
+                    },
+                    "autoComplete": {
+                      "description": "Value determining whether messages will be completed automatically, or whether the function will take responsibility message completion.",
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "eventHubs": { "$ref": "#/definitions/eventHubs-extension" },
+            "durableTask": { "$ref": "#/definitions/durableTask-extension" },
+            "cosmosDB": { "$ref": "#/definitions/cosmosDB-extension" }
+          }
+        }
+      },
+      "required": [ "version" ],
+      "additionalProperties": false
+    }
+  },
+
+  "oneOf": [
+    { "$ref": "#/definitions/version-1" },
+    { "$ref": "#/definitions/version-2" }
+  ]
+}


### PR DESCRIPTION
Now that our schema is shared between v1 and v2, it doesn't make sense to keep it alongside either branch in our Functions repo. So we'll keep it here instead before committing to the schemastore.

This is a rework of the schema to support both v1 and v2 simulatneously. All shared schemas are in `definititions`, and there is a `version-1` and `version-2` schema defined with `"oneOf"`. The switch is based on whether `"version": "2.0"` is set. If so, it's a v2 schema; otherwise, it's v1.

I let this auto-format in VS Code, but will clean it up a bit.

Fixes https://github.com/Azure/azure-functions-host/issues/3733