### PR TITLE
removing languageWorker.maxMessageLength from schema

### DIFF
--- a/schemas/host.json
+++ b/schemas/host.json
@@ -370,12 +370,6 @@
           "description": "Configuration settings for Language Workers.",
           "type": "object",
           "properties": {
-            "maxMessageLength": {
-              "description": "Defines maximum message size in MegaBytes (MB) for the streaming messages between the functions host and a language worker",
-              "type": "integer",
-              "minimum": 4,
-              "default": 32
-            },
             "workersDirectory": {
               "description": "Specifies full path of the directory for language workers",
               "type": "string"


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/3847