### PR TITLE
Use "bug" label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
Reason for change:

- All the other issue templates have a label.
- There is already a bug label: https://github.com/Azure/Azure-Functions/labels/bug